### PR TITLE
Remove CurrentSchema from DSN

### DIFF
--- a/lib/db2z.js
+++ b/lib/db2z.js
@@ -36,6 +36,21 @@ function DB2Z(settings) {
   debug('DB2Z constructor settings: %j', settings);
   IBMDB.call(this, 'db2z', settings);
 
+  if (this.dsn) {
+    this.connStr = this.dsn;
+  } else {
+    var connStrGenerate =
+      'DRIVER={db2z}' +
+      ';DATABASE=' + this.dbname +
+      ';HOSTNAME=' + this.hostname +
+      ';UID=' + this.username +
+      ';PWD=' + this.password +
+      ';PORT=' + this.portnumber +
+      ';PROTOCOL=' + this.protocol;
+
+    this.connStr = connStrGenerate;
+  }
+
   // This is less than ideal, better idea would be
   // to extend the propagation of the filter object
   // to executeSQL or pass the options obj around

--- a/test/db2z.connection.test.js
+++ b/test/db2z.connection.test.js
@@ -68,8 +68,7 @@ function generateDSN(config) {
     ';UID=' + config.username +
     ';PWD=' + config.password +
     ';PORT=' + config.port +
-    ';PROTOCOL=TCPIP' +
-    ';CurrentSchema=' + config.schema;
+    ';PROTOCOL=TCPIP';
   return dsn;
 }
 


### PR DESCRIPTION
@superkhau @Amir-61 PTAL

DB2z doesn't seem to work when the DSN includes the CurrentSchema keyword while DashDB and DB2 do not have issues with it.  This PR is a starting point for cleaning up of how Schema is used within IBM databases.  Follow on PRs for loopback-ibmdb, loopback-connector-db2, loopback-connector-informix, loopback-connector-dashdb and loopback-connector-db2iseries will be needed to simplify the use of Schema's within the connectors.
- [x] Backported
