### PR TITLE
Add missing functions part of refactor - DB2z

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -14,6 +14,80 @@ var async = require('async');
 var debug = require('debug')('loopback:connector:db2z');
 
 module.exports = function(DB2Z) {
+  DB2Z.prototype.getAddModifyColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getAddModifyColumns()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.getDropColumns = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getDropColumns()}} is not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.getColumnsToDrop = function(model, fields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{getColumnsToDrop()}} is not ' +
+      'currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.searchForPropertyInActual =
+  function(model, propName, actualFields) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{searchForPropertyInActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.addPropertyToActual = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{addPropertyToActual()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.columnDataType = function(model, property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{columnDataType()}} is not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.buildColumnType = function(property) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{buildColumnType()}} is not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.propertyHasNotBeenDeleted = function(model, propName) {
+    process.nextTick(function() {
+      throw new Error(g.f('{{propertyHasNotBeenDeleted()}} is ' +
+      'not currently supported.'));
+    });
+  };
+
+  DB2Z.prototype.applySqlChanges =
+  function(model, pendingChanges, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{applySqlChanges()}} is not ' +
+      'currently supported.')));
+    });
+  };
+
+  DB2Z.prototype.showFields = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showFields()}} is not currently supported.')));
+    });
+  };
+
+  DB2Z.prototype.showIndexes = function(model, cb) {
+    process.nextTick(function() {
+      return cb(Error(g.f('{{showIndexes()}} is not currently supported.')));
+    });
+  };
+
   /*
    * Perform autoupdate for the given models
    * @param {String[]} [models] A model name or an array of model names.

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "async": "^1.5.0",
     "debug": "^2.2.0",
-    "loopback-connector": "^2.3.0",
-    "loopback-ibmdb": "^1.0.1",
+    "loopback-connector": "^3.0.0",
+    "loopback-ibmdb": "^2.0.0",
     "strong-globalize": "^2.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
@qpresley PTAL

These are the functions that were refactored as a whole in the loopback base connector and ibmdb connector, and it will be overridden by the new definition **if** they are called for this connector.