### PR TITLE
Refactor alterTable function

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -14,26 +14,6 @@ var async = require('async');
 var debug = require('debug')('loopback:connector:db2z');
 
 module.exports = function(DB2Z) {
-  DB2Z.prototype.getAddModifyColumns = function(model, fields) {
-    process.nextTick(function() {
-      throw new Error(g.f('{{getAddModifyColumns()}} is ' +
-      'not currently supported.'));
-    });
-  };
-
-  DB2Z.prototype.getDropColumns = function(model, fields) {
-    process.nextTick(function() {
-      throw new Error(g.f('{{getDropColumns()}} is not currently supported.'));
-    });
-  };
-
-  DB2Z.prototype.getColumnsToDrop = function(model, fields) {
-    process.nextTick(function() {
-      throw new Error(g.f('{{getColumnsToDrop()}} is not ' +
-      'currently supported.'));
-    });
-  };
-
   DB2Z.prototype.searchForPropertyInActual =
   function(model, propName, actualFields) {
     process.nextTick(function() {
@@ -168,11 +148,85 @@ module.exports = function(DB2Z) {
     });
   };
 
-  DB2Z.prototype.alterTable = function(model, actualFields, actualIndexes,
-                                      callback, checkOnly) {
-    debug('DB2Z.prototype.alterTable %j %j %j %j %j',
-          model, actualFields, actualIndexes, checkOnly);
+  DB2Z.prototype.getColumnsToAdd = function(model, actualFields) {
+    var self = this;
+    var m = this.getModelDefinition(model);
+    var propNames = Object.keys(m.properties).filter(function(name) {
+      return !!m.properties[name];
+    });
+    var operations = [];
 
+    // change/add new fields
+    propNames.forEach(function(propName) {
+      if (m.properties[propName] && self.id(model, propName)) return;
+      var found;
+      if (actualFields) {
+        actualFields.forEach(function(f) {
+          if (f.NAME === propName) {
+            found = f;
+          }
+        });
+      }
+
+      if (found) {
+        actualize(propName, found);
+      } else {
+        operations.push('ADD COLUMN ' + propName + ' ' +
+          self.buildColumnDefinition(model, propName));
+      }
+    });
+
+    function actualize(propName, oldSettings) {
+      var newSettings = m.properties[propName];
+      if (newSettings && changed(newSettings, oldSettings)) {
+        // TODO: NO TESTS EXECUTE THIS CODE PATH
+        var pName = '\'' + propName + '\'';
+        operations.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
+          self.buildColumnDefinition(model, propName));
+      }
+    }
+
+    function changed(newSettings, oldSettings) {
+      if (oldSettings.Null === 'YES') {
+        // Used to allow null and does not now.
+        if (!self.isNullable(newSettings)) {
+          return true;
+        }
+      }
+      if (oldSettings.Null === 'NO') {
+        // Did not allow null and now does.
+        if (self.isNullable(newSettings)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+    return operations;
+  };
+
+  DB2Z.prototype.getColumnsToDrop = function(model, actualFields) {
+    var self = this;
+    var m = this._models[model];
+    var propNames = Object.keys(m.properties).filter(function(name) {
+      return !!m.properties[name];
+    });
+    var operations = [];
+
+    // drop columns
+    if (actualFields) {
+      actualFields.forEach(function(f) {
+        var notFound = !~propNames.indexOf(f.NAME);
+        if (m.properties[f.NAME] && self.id(model, f.NAME)) return;
+        if (notFound || !m.properties[f.NAME]) {
+          operations.push('DROP COLUMN ' + f.NAME);
+        }
+      });
+    }
+    return operations;
+  };
+
+  DB2Z.prototype.addIndexes = function(model, actualIndexes) {
     var self = this;
     var m = this.getModelDefinition(model);
     var propNames = Object.keys(m.properties).filter(function(name) {
@@ -209,45 +263,6 @@ module.exports = function(DB2Z) {
       });
     }
     var aiNames = Object.keys(ai);
-
-    // change/add new fields
-    propNames.forEach(function(propName) {
-      if (m.properties[propName] && self.id(model, propName)) return;
-      var found;
-      if (actualFields) {
-        actualFields.forEach(function(f) {
-          if (f.NAME === propName) {
-            found = f;
-          }
-        });
-      }
-
-      if (found) {
-        actualize(propName, found);
-      } else {
-        operations.push('ADD COLUMN ' + propName + ' ' +
-          self.buildColumnDefinition(model, propName));
-      }
-    });
-
-    // drop columns
-    if (actualFields) {
-      actualFields.forEach(function(f) {
-        var notFound = !~propNames.indexOf(f.NAME);
-        if (m.properties[f.NAME] && self.id(model, f.NAME)) return;
-        if (notFound || !m.properties[f.NAME]) {
-          operations.push('DROP COLUMN ' + f.NAME);
-        }
-      });
-    }
-
-    if (operations.length) {
-      // Add the ALTER TABLE statement to the list of tasks to perform later.
-      sql.push('ALTER TABLE ' + self.schema + '.' +
-               self.tableEscaped(model) + ' ' + operations.join(' ') + ';');
-    }
-
-    operations = [];
 
     // remove indexes
     aiNames.forEach(function(indexName) {
@@ -334,6 +349,28 @@ module.exports = function(DB2Z) {
         sql.push(stmt);
       }
     });
+    return sql;
+  };
+
+  DB2Z.prototype.alterTable = function(model, actualFields, actualIndexes,
+                                      callback, checkOnly) {
+    debug('DB2Z.prototype.alterTable %j %j %j %j %j',
+          model, actualFields, actualIndexes, checkOnly);
+
+    var self = this;
+    var sql = [];
+    var tasks = [];
+
+    var operations = self.getAddModifyColumns(model, actualFields);
+    operations = operations.concat(self.getDropColumns(model, actualFields));
+
+    if (operations.length) {
+      // Add the ALTER TABLE statement to the list of tasks to perform later.
+      sql.push('ALTER TABLE ' + self.schema + '.' +
+               self.tableEscaped(model) + ' ' + operations.join(' ') + ';');
+    }
+
+    sql = sql.concat(self.addIndexes(model, actualIndexes));
 
     sql.forEach(function(i) {
       tasks.push(function(cb) {
@@ -353,33 +390,6 @@ module.exports = function(DB2Z) {
       }
     } else {
       return (callback());
-    }
-
-    function actualize(propName, oldSettings) {
-      var newSettings = m.properties[propName];
-      if (newSettings && changed(newSettings, oldSettings)) {
-        // TODO: NO TESTS EXECUTE THIS CODE PATH
-        var pName = '\'' + propName + '\'';
-        operations.push('CHANGE COLUMN ' + pName + ' ' + pName + ' ' +
-          self.buildColumnDefinition(model, propName));
-      }
-    }
-
-    function changed(newSettings, oldSettings) {
-      if (oldSettings.Null === 'YES') {
-        // Used to allow null and does not now.
-        if (!self.isNullable(newSettings)) {
-          return true;
-        }
-      }
-      if (oldSettings.Null === 'NO') {
-        // Did not allow null and now does.
-        if (self.isNullable(newSettings)) {
-          return true;
-        }
-      }
-
-      return false;
     }
   };
 

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -352,47 +352,6 @@ module.exports = function(DB2Z) {
     return sql;
   };
 
-  DB2Z.prototype.alterTable = function(model, actualFields, actualIndexes,
-                                      callback, checkOnly) {
-    debug('DB2Z.prototype.alterTable %j %j %j %j %j',
-          model, actualFields, actualIndexes, checkOnly);
-
-    var self = this;
-    var sql = [];
-    var tasks = [];
-
-    var operations = self.getAddModifyColumns(model, actualFields);
-    operations = operations.concat(self.getDropColumns(model, actualFields));
-
-    if (operations.length) {
-      // Add the ALTER TABLE statement to the list of tasks to perform later.
-      sql.push('ALTER TABLE ' + self.schema + '.' +
-               self.tableEscaped(model) + ' ' + operations.join(' ') + ';');
-    }
-
-    sql = sql.concat(self.addIndexes(model, actualIndexes));
-
-    sql.forEach(function(i) {
-      tasks.push(function(cb) {
-        self.execute(i, function(err, results) {
-          cb(err);
-        });
-      });
-    });
-
-    if (tasks.length) {
-      if (checkOnly) {
-        return (callback(null, true, {statements: sql}));
-      } else {
-        async.series(tasks, function() {
-          return (callback());
-        });
-      }
-    } else {
-      return (callback());
-    }
-  };
-
   DB2Z.prototype.isActual = function(models, cb) {
     debug('DB2Z.prototype.isActual %j %j', models, cb);
     var self = this;


### PR DESCRIPTION
Extract out the logic of `alterTable` function and break them into smaller functions to unify the logic across all LB connectors.