### PR TITLE
Drop Node.js 4 in CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,8 @@
 # Each line is a file pattern followed by one or more owners,
 # the last matching pattern has the most precendence.
 
+# Alumni maintainers
+# @kjdelisle @loay @ssh24 
+
 # Core team members from IBM
-* @kjdelisle @jannyHou @loay @b-admike @ssh24 @virkt25 @dhmlau
+* @jannyHou @b-admike @virkt25 @dhmlau @shimks

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "description": "LoopBack Connector for IBM DB2 for z/OS",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "keywords": [
     "IBM",
@@ -21,17 +21,17 @@
   },
   "dependencies": {
     "async": "^1.5.0",
-    "debug": "^2.2.0",
+    "debug": "^3.1.0",
     "loopback-connector": "^4.0.0",
     "loopback-ibmdb": "^2.0.0",
-    "strong-globalize": "^2.8.0"
+    "strong-globalize": "^4.1.1"
   },
   "devDependencies": {
     "bluebird": "^2.9.9",
     "eslint": "^2.13.1",
     "eslint-config-loopback": "^4.0.0",
     "loopback-datasource-juggler": "^3.0.0",
-    "mocha": "^2.3.4",
+    "mocha": "^5.2.0",
     "rc": "^1.1.5",
     "should": "^8.1.1",
     "sinon": "^1.17.2"


### PR DESCRIPTION
### Description
- Drop Node.js 4 in CI
- Update CODEOWNERS to reflect the current status
- Update dependencies
